### PR TITLE
fix: Regenerate PipFile.lock

### DIFF
--- a/listingapi/Dockerfile
+++ b/listingapi/Dockerfile
@@ -10,6 +10,7 @@ RUN pip3 install pipenv
 COPY Pipfile Pipfile.lock ./
 
 ENV PATH /home/listingapi/.local/bin:${PATH}
+RUN pipenv lock
 RUN pipenv install --deploy --system
 
 ENV PYTHONPATH /home/listingapi/app


### PR DESCRIPTION
Because of the light version restrictions on the Pipfile, It may have some delta betweek hashes from the versioned Pipfile.lock and the installed packages.

Here, I re-generate Pipfile.lock before install anything